### PR TITLE
fix: add timestamp field to health endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ app.use(express.json());
 app.get("/health", (req, res) => {
   res.status(200).json({
     status: "ok",
+    timestamp: new Date().toISOString(),
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `timestamp` field to `/health` endpoint response containing current date and time in ISO 8601 format
- Fix issue XXX where the health endpoint was missing the timestamp field

## Changes Made
- Modified `src/index.ts:11` to include `timestamp: new Date().toISOString()` in the health endpoint response
- The timestamp is generated on each request and returns the current date/time in ISO 8601 format (e.g., "2025-10-03T20:47:32.123Z")

## Test plan
- [x] TypeScript compilation passes without errors
- [x] Code change is minimal and non-breaking (only adds a new field to the response)
- [ ] Manual testing: Start server and verify `/health` endpoint returns both `status` and `timestamp` fields
- [ ] Verify timestamp format is ISO 8601 compliant

## Example Response
```json
{
  "status": "ok",
  "timestamp": "2025-10-03T20:47:32.123Z"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)